### PR TITLE
Make wording clearer

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -328,14 +328,16 @@ function App() {
                       Harmonise questionnaire items
                     </h1>
                     <p>
-                      Harmony is a tool which can read questionnaires and find questions with similar meanings, such as{" "}
+                      Harmony is an AI tool which can read questionnaires and find questions with similar meanings, such as{" "}
                       <i>anxiety</i> vs <i>I feel anxious</i>?
                     </p>
                     <p>
-                      This is a common problem in psychology, politics, market
-                      research, and the social sciences, especially when surveys
+                      Psychologists, political pollers, market researchers, and other social scientists sometimes need to combine data from different questionnaires, especially when surveys
                       have been run by different organisations or in different
                       countries.
+                    </p>
+                    <p>
+                      Try Harmony with two example PDFs: <a href="https://adaa.org/sites/default/files/GAD-7_Anxiety-updated_0.pdf">GAD-7 PDF</a> vs <a href="https://www.apa.org/depression-guideline/patient-health-questionnaire.pdf">PHQ-9 PDF</a>.
                     </p>
                     <p>
                       <a

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -332,12 +332,12 @@ function App() {
                       <i>anxiety</i> vs <i>I feel anxious</i>?
                     </p>
                     <p>
-                      Psychologists, political pollers, market researchers, and other social scientists sometimes need to combine data from different questionnaires, especially when surveys
+                      Psychologists sometimes need to combine survey results, especially when surveys
                       have been run by different organisations or in different
                       countries.
                     </p>
                     <p>
-                      Try Harmony with two example PDFs: <a href="https://adaa.org/sites/default/files/GAD-7_Anxiety-updated_0.pdf">GAD-7 PDF</a> vs <a href="https://www.apa.org/depression-guideline/patient-health-questionnaire.pdf">PHQ-9 PDF</a>.
+                      Try Harmony with two example PDFs: <a  style={{ color: "white" }} href="https://adaa.org/sites/default/files/GAD-7_Anxiety-updated_0.pdf">GAD-7 PDF</a> vs <a  style={{ color: "white" }} href="https://www.apa.org/depression-guideline/patient-health-questionnaire.pdf">PHQ-9 PDF</a>.
                     </p>
                     <p>
                       <a

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -325,11 +325,10 @@ function App() {
                 <Route path="*">
                   <div>
                     <h1 style={{ color: "white" }}>
-                      Harmonise questionnaire items - with Harmony
+                      Harmonise questionnaire items
                     </h1>
                     <p>
-                      Do you need to combine surveys or questionnaires with
-                      different wording for similar questions, such as{" "}
+                      Harmony is a tool which can read questionnaires and find questions with similar meanings, such as{" "}
                       <i>anxiety</i> vs <i>I feel anxious</i>?
                     </p>
                     <p>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -337,7 +337,7 @@ function App() {
                       countries.
                     </p>
                     <p>
-                      Try Harmony with two example PDFs: <a  style={{ color: "white" }} href="https://adaa.org/sites/default/files/GAD-7_Anxiety-updated_0.pdf">GAD-7 PDF</a> vs <a  style={{ color: "white" }} href="https://www.apa.org/depression-guideline/patient-health-questionnaire.pdf">PHQ-9 PDF</a>.
+                      Try two example PDFs: <a target="gad7-pdf" style={{ color: "white" }} href="https://adaa.org/sites/default/files/GAD-7_Anxiety-updated_0.pdf">GAD-7 PDF</a> vs <a target="phq-pdf" style={{ color: "white" }} href="https://www.apa.org/depression-guideline/patient-health-questionnaire.pdf">PHQ-9 PDF</a>.
                     </p>
                     <p>
                       <a

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -329,7 +329,7 @@ function App() {
                     </h1>
                     <p>
                       Harmony is an AI tool which can read questionnaires and find questions with similar meanings, such as{" "}
-                      <i>anxiety</i> vs <i>I feel anxious</i>?
+                      <i>anxiety</i> vs <i>I feel anxious</i>.
                     </p>
                     <p>
                       Psychologists sometimes need to combine survey results, especially when surveys

--- a/src/components/DragDrop.js
+++ b/src/components/DragDrop.js
@@ -74,8 +74,8 @@ function DragDrop({
           <UploadFileIcon sx={{ width: "2rem", height: "2rem" }} />
           <div>
             <p>
-              <u>Upload</u> or drag and drop any{" "}
-              <b>pdf, csv, txt, docx or xlsx</b> file here
+              <u>Upload</u> or drag and drop one or more questionnaires here.{" "}
+              Files can be in <b>pdf, csv, txt, docx or xlsx</b> format (<a href="https://harmonydata.ac.uk/formatting-help/">examples</a>)
             </p>
           </div>
         </>

--- a/src/components/ExistingInstruments.js
+++ b/src/components/ExistingInstruments.js
@@ -41,7 +41,7 @@ export default function ExistingInstruments({
     <Box sx={sx}>
       <FormControl sx={{ margin: "auto", width: "100%" }}>
         <InputLabel id="ExistingInstruments">
-          or choose from existing instruments:
+          or you can choose from Harmony's database of questionnaires
         </InputLabel>
         <Select
           labelId="ExistingInstruments"
@@ -51,7 +51,7 @@ export default function ExistingInstruments({
             return allInstrumentNames.includes(i);
           })}
           onChange={handleChange}
-          input={<OutlinedInput label="or choose from existing instruments" />}
+          input={<OutlinedInput label="or you can choose from Harmony's database of questionnaires" />}
           renderValue={(selected) => selected.join(", ")}
           MenuProps={MenuProps}
         >


### PR DESCRIPTION
Hi John

Please can we consider merging this change of wording again? I've tested on a few people and they were still finding it hard to understand what the tool is for, how to use it etc.

However, before merging the pull request, please note I added a hyperlink inside the drag-and-drop box, so that people can see how to get examples. Is there a way to make it clickable? I didn't know how to do that.

The little circular question mark inside the drag-and-drop box is also not getting noticed by most users. Can we make it a little more prominent or add a text saying "help"? Not sure what you think we can do here?

old:
![image](https://github.com/harmonydata/app/assets/15210965/c7f97979-0a9d-4300-b8c7-165a6c83cf00)

new:
![image](https://github.com/harmonydata/app/assets/15210965/fbaefad4-bf5d-4ad4-892c-5865ff8712f3)
